### PR TITLE
fix: Stops crash if project image or blog missing.

### DIFF
--- a/astro-tutorial/src/layouts/ProjectLayout.astro
+++ b/astro-tutorial/src/layouts/ProjectLayout.astro
@@ -106,7 +106,7 @@ const pubInfoArray = generatePublicationLinks(frontmatter)
             <div class="flex flex-wrap gap-2 mb-2">
               <p class="font-bold pr-2">Related blog posts:</p>
               {relatedBlogPosts.map(blog => (
-                <Link text={blog.data.title} url={`../../blog/${blog.slug}`} />
+                <Link text={blog?.data?.title} url={`../../blog/${blog?.slug}`} />
               ))}
             </div>
           )}

--- a/astro-tutorial/src/pages/projects/index.astro
+++ b/astro-tutorial/src/pages/projects/index.astro
@@ -43,13 +43,14 @@ const uniqueTags = extractUniqueTags(allProjects)
                             tagline={project.data.tagline}
                             tagsArray={extractIndividualProjectTags(project.data)}
                         >
-                            <Image 
+                            {project?.data['image file'] ? (
+                              <Image 
                                 slot="image" 
                                 src={project.data['image file']} 
                                 alt={project.data['image alt text']}
                                 class="w-full h-40 object-cover object-center"
                                 loading="eager"
-                            />
+                            />) : ''}
                         </ProjectCard>
                     )
                 })


### PR DESCRIPTION
If the optional project image or the related blog posts are missing, the site should still render without them. Although, the image looks less optional to me and if it is missing, maybe a placeholder image would be better than nothing.