### PR TITLE
Fix - selecting and deselecting tags.

### DIFF
--- a/astro-tutorial/src/components/projects/stores/tagsStore.js
+++ b/astro-tutorial/src/components/projects/stores/tagsStore.js
@@ -1,5 +1,4 @@
 import { atom } from 'nanostores'
-import {useStore} from '@nanostores/react'
 import { capitalizeTag } from '../../../utils/tagManipulation';
 
 export const selectedTags = atom([])
@@ -12,6 +11,7 @@ export function handleTagSelection(tag) {
     if (tagIndex === -1) {
       selectedTags.set([...prevTags, normalizedTag]);
     } else {
-      selectedTags.set(prevTags.splice(tagIndex, 1));
+      const updatedTags = prevTags.filter((t, index) => index !== tagIndex);      
+      selectedTags.set(updatedTags);
     }
 };


### PR DESCRIPTION
Filter out the tag if it is double-selected (double-clicked) rather than splice. This is to address a bug where if multiple tags were selected, and then one was selected again, all the other tags except the one that was double-selected got de-selected (the opposite of what I want to happen)