### PR TITLE
style: keep focus on project type button

### DIFF
--- a/src/components/projects/CardsAndFiltersIsland.jsx
+++ b/src/components/projects/CardsAndFiltersIsland.jsx
@@ -22,8 +22,8 @@ export default function CardsAndFiltersIsland({
         <ProjectTypeBtns contentType={contentType} />
         <div className="md:hidden flex items-end justify-between pb-8">
           <div className={`${contentType === "ecosystems" && "hidden"} w-1/2`}>
-            <h3 className="cursor-pointer font-bold flex items-center justify-between py-2">
-              Project type
+            <h3 className="font-bold flex items-center justify-between py-2">
+              Filter by OSSI funding status
             </h3>
             <ProjectTypeDropdown />
           </div>

--- a/src/components/projects/FilterMenu.jsx
+++ b/src/components/projects/FilterMenu.jsx
@@ -42,6 +42,9 @@ export default function FilterMenu({ uniqueTags }) {
         <TbX />
       </button>
       <div className="overflow-y-scroll md:overflow-hidden px-2">
+        <h3 className="hidden md:flex items-center justify-between py-2 font-bold ">
+          Filter by tag
+        </h3>
         {Object.keys(uniqueTags).map((key) => (
           <div className="mb-4" key={`tagCategory-${key}`}>
             <h3

--- a/src/components/projects/ProjectTypeBtns.jsx
+++ b/src/components/projects/ProjectTypeBtns.jsx
@@ -1,33 +1,55 @@
 import { selectedProjectType } from "./stores/selectedProjectTypeStore.js";
+import { useStore } from "@nanostores/react";
 
 export default function ProjectTypeSelector({ contentType }) {
+  const currentProjectType = useStore(selectedProjectType);
+
+  const handleButtonClick = (type) => {
+    selectedProjectType.set(type);
+  };
+
+  const isSelected = (type) => currentProjectType === type;
+
   return (
     <div className={`${contentType === "ecosystems" && "hidden"} "pb-6"`}>
-      <div className="hidden md:flex gap-4 ">
-        <button
-          className="flex-1 btn-secondary px-2"
-          onClick={() => selectedProjectType.set("OSSI - current")}
-        >
-          Current OSSI projects
-        </button>
-        <button
-          className="flex-1 btn-secondary px-2"
-          onClick={() => selectedProjectType.set("OSSI - previous")}
-        >
-          Previous OSSI projects
-        </button>
-        <button
-          className="flex-1 btn-secondary px-2"
-          onClick={() => selectedProjectType.set("Other")}
-        >
-          Other projects
-        </button>
-        <button
-          className="flex-1 btn-secondary px-2"
-          onClick={() => selectedProjectType.set("All")}
-        >
-          All projects
-        </button>
+      <div className="md:flex-col">
+        <h3 className="hidden md:flex items-center justify-between py-2 font-bold ">
+          Filter by OSSI funding status
+        </h3>
+        <div className="hidden md:flex gap-4">
+          <button
+            className={`flex-1 btn-filter px-2 ${
+              isSelected("OSSI - current") ? "bg-primary text-white" : ""
+            }`}
+            onClick={() => handleButtonClick("OSSI - current")}
+          >
+            Current OSSI projects
+          </button>
+          <button
+            className={`flex-1 btn-filter px-2 ${
+              isSelected("OSSI - previous") ? "bg-primary text-white" : ""
+            }`}
+            onClick={() => handleButtonClick("OSSI - previous")}
+          >
+            Previous OSSI projects
+          </button>
+          <button
+            className={`flex-1 btn-filter px-2 ${
+              isSelected("Other") ? "bg-primary text-white" : ""
+            }`}
+            onClick={() => handleButtonClick("Other")}
+          >
+            Other projects
+          </button>
+          <button
+            className={`flex-1 btn-filter px-2 ${
+              isSelected("All") ? "bg-primary text-white" : ""
+            }`}
+            onClick={() => handleButtonClick("All")}
+          >
+            All projects
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/projects/ProjectTypeDropdown.jsx
+++ b/src/components/projects/ProjectTypeDropdown.jsx
@@ -11,17 +11,14 @@ const getOptionColorClasses = ({ selected, highlighted, disabled }) => {
   if (disabled) {
     classes += " text-slate-400 dark:text-slate-700";
   } else {
-    if (selected) {
-      classes +=
-        " bg-purple-100 dark:bg-purple-950 text-purple-950 dark:text-purple-50";
-    } else if (highlighted) {
-      classes +=
-        " bg-slate-100 dark:bg-neutral-800 text-slate-900 dark:text-slate-300";
+    if (selected || highlighted) {
+      classes += " bg-primary text-white dark:text-slate-100";
+      // } else if (highlighted) {
+      //   classes +=
+      //     " bg-slate-100 dark:bg-neutral-800 text-slate-900 dark:text-slate-300";
     }
     classes +=
       "hover:dark:bg-neutral-800 hover:bg-slate-100 hover:dark:text-slate-300 hover:text-slate-900";
-    classes +=
-      "focus-visible:outline focus-visible:outline-2 focus-visible:outline-purple-400 focus-visible:dark:outline-purple-300";
   }
   return classes;
 };

--- a/src/components/projects/ToggleFilterMenuBtn.jsx
+++ b/src/components/projects/ToggleFilterMenuBtn.jsx
@@ -22,7 +22,7 @@ export default function ToggleFilterMenuBtn() {
       }}
     >
       <button
-        className="md:hidden btn-secondary flex gap-2 py-2 px-3"
+        className="md:hidden btn-filter flex gap-2 py-2 px-3"
         onClick={() => isFilterMenuVisible.set(!$isFilterMenuVisible)}
       >
         <p className="text-sm">Filter by tag</p>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -22,7 +22,7 @@
 
 @layer components {
   .btn {
-    @apply inline-flex items-center justify-center rounded-full border-gray-400 border bg-transparent font-medium text-center text-base text-page leading-snug transition py-3.5 px-6 md:px-8 ease-in duration-200 focus:ring-blue-500 focus:ring-offset-blue-200 focus:ring-2 focus:ring-offset-2 hover:bg-gray-100 hover:border-gray-600 dark:text-slate-200 dark:border-slate-500 dark:hover:bg-slate-800 dark:hover:border-slate-800 cursor-pointer;
+    @apply inline-flex items-center justify-center rounded-full border-gray-400 border bg-transparent font-medium text-center text-base text-page leading-snug transition py-3.5 px-6 md:px-8 ease-in duration-200 focus:ring-blue-500 focus:ring-offset-blue-200 focus:ring-2 focus:ring-offset-2 hover:bg-gray-100 hover:border-gray-600 dark:text-slate-100 dark:border-slate-500 dark:hover:bg-slate-800 dark:hover:border-slate-800 cursor-pointer;
   }
 
   .btn-primary {
@@ -33,7 +33,8 @@
     @apply btn rounded-md shadow-none p-1 md:py-4 md:px-8 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white;
   }
 
-  .btn-tertiary {
+  .btn-filter {
+    @apply btn rounded-md shadow-none p-1 md:py-4 md:px-8 border-2 dark:border-slate-400 hover:bg-primary hover:border-primary dark:hover:bg-primary focus:bg-primary focus:border-primary;
   }
 }
 


### PR DESCRIPTION
Also fixed styling on the project type dropdown menu (visible on small screens) and added labels to the two filter sections (tag filters and project type filters) to make clear the purpose of each to the user.