### PR TITLE
feat: URL search params for tags and project type

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -16,7 +16,7 @@ const baseUrl = import.meta.env.BASE_URL;
   >
   </div>
 
-  <div class="relative max-w-7xl mx-auto px-4 sm:px-6 dark:text-slate-300">
+  <div class="relative l mx-auto px-4 sm:px-6 dark:text-slate-300">
     <div class="flex justify-between items-start my-6">
       <div>
         <div class="mb-2">

--- a/src/components/projects/CardsAndFiltersIsland.jsx
+++ b/src/components/projects/CardsAndFiltersIsland.jsx
@@ -23,7 +23,7 @@ export default function CardsAndFiltersIsland({
     const searchParams = new URLSearchParams(window.location.search);
 
     // Check for 'tags' in the query string and update the selectedTags store
-    const tags = searchParams.getAll("tags");
+    const tags = searchParams.getAll("tag");
     if (tags.length) {
       selectedTags.set(tags);
     }
@@ -58,7 +58,7 @@ export default function CardsAndFiltersIsland({
             </button>
             <ProjectTypeDropdown />
           </div>
-          <ToggleFilterMenuBtn uniqueTags />
+          <ToggleFilterMenuBtn uniqueTags={uniqueTags} />
         </div>
 
         <ProjectCount allContent={allContent} contentType={contentType} />

--- a/src/components/projects/CardsAndFiltersIsland.jsx
+++ b/src/components/projects/CardsAndFiltersIsland.jsx
@@ -41,7 +41,7 @@ export default function CardsAndFiltersIsland({
         <FilterMenu uniqueTags={uniqueTags} />
       </div>
 
-      <div className="col-start-2 col-span-2 ">
+      <div className="col-start-2 col-span-2">
         <ProjectTypeBtns contentType={contentType} />
         <div
           className={`md:hidden ${
@@ -58,8 +58,7 @@ export default function CardsAndFiltersIsland({
             </button>
             <ProjectTypeDropdown />
           </div>
-
-          <ToggleFilterMenuBtn />
+          <ToggleFilterMenuBtn uniqueTags />
         </div>
 
         <ProjectCount allContent={allContent} contentType={contentType} />

--- a/src/components/projects/CardsAndFiltersIsland.jsx
+++ b/src/components/projects/CardsAndFiltersIsland.jsx
@@ -5,6 +5,10 @@ import { extractUniqueTagsObject } from "../../utils/tagManipulation.js";
 import ProjectTypeBtns from "./ProjectTypeBtns.jsx";
 import ToggleFilterMenuBtn from "./ToggleFilterMenuBtn.jsx";
 import ProjectTypeDropdown from "./ProjectTypeDropdown.jsx";
+import { useState, useEffect } from "react";
+import { useStore } from "@nanostores/react";
+import { selectedTags } from "./stores/selectedTagsStore.js";
+import { selectedProjectType } from "./stores/selectedProjectTypeStore.js";
 
 export default function CardsAndFiltersIsland({
   uniqueTags,
@@ -12,6 +16,25 @@ export default function CardsAndFiltersIsland({
   baseUrl,
   contentType,
 }) {
+  // const $selectedTags = useStore(selectedTags);
+  // const $selectedProjectType = useStore(selectedProjectType);
+
+  useEffect(() => {
+    const searchParams = new URLSearchParams(window.location.search);
+
+    // Check for 'tags' in the query string and update the selectedTags store
+    const tags = searchParams.getAll("tags");
+    if (tags.length) {
+      selectedTags.set(tags);
+    }
+
+    // Check for 'projectType' in the query string and update the selectedProjectType store
+    const projectType = searchParams.getAll("projectType"); // Gets the first 'projectType' value - need to
+    if (projectType.length) {
+      selectedProjectType.set(projectType);
+    }
+  }, []);
+
   return (
     <section className="px-6 py-6 md:py-12 lg:py-20 mx-auto max-w-6xl md:grid grid-cols-3 gap-4 ">
       <div className="col-start-1 col-span-1 ">

--- a/src/components/projects/CardsAndFiltersIsland.jsx
+++ b/src/components/projects/CardsAndFiltersIsland.jsx
@@ -8,7 +8,10 @@ import ProjectTypeDropdown from "./ProjectTypeDropdown.jsx";
 import { useState, useEffect } from "react";
 import { useStore } from "@nanostores/react";
 import { selectedTags } from "./stores/selectedTagsStore.js";
-import { selectedProjectType } from "./stores/selectedProjectTypeStore.js";
+import {
+  selectedProjectType,
+  handleProjectTypeDropdown,
+} from "./stores/selectedProjectTypeStore.js";
 
 export default function CardsAndFiltersIsland({
   uniqueTags,
@@ -16,9 +19,6 @@ export default function CardsAndFiltersIsland({
   baseUrl,
   contentType,
 }) {
-  const $selectedTags = useStore(selectedTags);
-  const $selectedProjectType = useStore(selectedProjectType);
-
   useEffect(() => {
     const searchParams = new URLSearchParams(window.location.search);
 
@@ -43,13 +43,22 @@ export default function CardsAndFiltersIsland({
 
       <div className="col-start-2 col-span-2 ">
         <ProjectTypeBtns contentType={contentType} />
-        <div className="md:hidden flex items-end justify-between pb-8">
-          <div className={`${contentType === "ecosystems" && "hidden"} w-1/2`}>
-            <h3 className="font-bold flex items-center justify-between py-2">
-              Filter by OSSI funding status
-            </h3>
+        <div
+          className={`md:hidden ${
+            contentType === "ecosystems" ? "hidden" : "flex"
+          } flex-col gap-6 items-end min-w-full`}
+        >
+          <div className="flex gap-2 w-full">
+            <h3 className="font-bold">Filter by OSSI funding status</h3>
+            <button
+              className="btn-reset text-xs "
+              onClick={() => handleProjectTypeDropdown([])}
+            >
+              Reset
+            </button>
             <ProjectTypeDropdown />
           </div>
+
           <ToggleFilterMenuBtn />
         </div>
 

--- a/src/components/projects/CardsAndFiltersIsland.jsx
+++ b/src/components/projects/CardsAndFiltersIsland.jsx
@@ -16,8 +16,8 @@ export default function CardsAndFiltersIsland({
   baseUrl,
   contentType,
 }) {
-  // const $selectedTags = useStore(selectedTags);
-  // const $selectedProjectType = useStore(selectedProjectType);
+  const $selectedTags = useStore(selectedTags);
+  const $selectedProjectType = useStore(selectedProjectType);
 
   useEffect(() => {
     const searchParams = new URLSearchParams(window.location.search);

--- a/src/components/projects/ContentCard.jsx
+++ b/src/components/projects/ContentCard.jsx
@@ -34,9 +34,8 @@ export default function ContentCard({
       className={`${
         ($selectedTags.length &&
           !tagsArray.some((tag) => $selectedTags.includes(tag))) ||
-        ($selectedProjectType &&
-          $selectedProjectType != "All" &&
-          $selectedProjectType != projectType)
+        ($selectedProjectType.length &&
+          !$selectedProjectType.includes(projectType))
           ? "hidden"
           : ""
       } col-span-1 w-full h-full mx-auto mb-4 bg-white dark:bg-slate-900 rounded-md shadow-md overflow-hidden border-gray-200 dark:border-slate-800 border-2 hover:shadow-lg transition duration-300 transform hover:scale-105`}
@@ -80,14 +79,11 @@ export default function ContentCard({
 
         <div className="flex flex-wrap gap-2 px-4 py-2">
           {Object.entries(tagsObj).map(([key, tags]) => {
-            return tags.map((tag, index) => {
-              const tagClass = `bg-primary text-white px-1.5 py-1 rounded-md text-xs ${
-                index < 3 ? "" : "hidden"
-              }`;
+            return tags.map((tag) => {
               return (
                 <span
                   key={`${title} ${tag}`}
-                  className={tagClass}
+                  className="bg-primary text-white px-1.5 py-1 rounded-md text-xs"
                   style={{ backgroundColor: getBackgroundColor(key) }}
                 >
                   {tag}

--- a/src/components/projects/FilterDropdowns.jsx
+++ b/src/components/projects/FilterDropdowns.jsx
@@ -66,7 +66,7 @@ Button.propTypes = {
 
 export default function FilterDropdowns({ tagCategory, tags }) {
   const $selectedTags = useStore(selectedTags);
-  console.log("$selectedTags[tagCategory]: ", $selectedTags[tagCategory]);
+  // console.log("$selectedTags[tagCategory]: ", $selectedTags[tagCategory]);
   return (
     <Select
       defaultValue={$selectedTags[tagCategory]}

--- a/src/components/projects/FilterMenu.jsx
+++ b/src/components/projects/FilterMenu.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useStore } from "@nanostores/react";
 import { TbMinus, TbPlus, TbX } from "react-icons/tb";
 import { isFilterMenuVisible } from "./stores/isFilterMenuVisibleStore.js";
@@ -10,7 +10,6 @@ import { getBackgroundColor } from "../../utils/tagManipulation.js";
 
 export default function FilterMenu({ uniqueTags }) {
   const $selectedTags = useStore(selectedTags);
-
   //used to manage state for the close ("x") button on the small screen filter menu
   const $isFilterMenuVisible = useStore(isFilterMenuVisible);
 
@@ -22,6 +21,18 @@ export default function FilterMenu({ uniqueTags }) {
     });
     return initialVisibility;
   });
+
+  // Effect to update categoryVisibility when $selectedTags changes
+  useEffect(() => {
+    const newVisibility = {};
+    Object.keys(uniqueTags).forEach((key) => {
+      newVisibility[key] = uniqueTags[key].some((tag) =>
+        $selectedTags.includes(tag)
+      );
+    });
+    setCategoryVisibility(newVisibility);
+  }, [$selectedTags]);
+
   const toggleCategoryVisibility = (categoryKey) => {
     setCategoryVisibility((prevVisibility) => ({
       ...prevVisibility,

--- a/src/components/projects/FilterMenu.jsx
+++ b/src/components/projects/FilterMenu.jsx
@@ -53,9 +53,13 @@ export default function FilterMenu({ uniqueTags }) {
         <TbX />
       </button>
       <div className="overflow-y-scroll md:overflow-hidden px-2">
-        <h3 className="hidden md:flex items-center justify-between py-2 font-bold ">
-          Filter by tag
-        </h3>
+        <div className="flex items-center justify-between pt-2 pb-4">
+          <h3 className="hidden md:flex text-lg font-bold ">Filter by tag</h3>
+          <button className="btn-reset" onClick={() => selectedTags.set([])}>
+            Reset
+          </button>
+        </div>
+
         {Object.keys(uniqueTags).map((key) => (
           <div className="mb-4" key={`tagCategory-${key}`}>
             <h3
@@ -100,8 +104,8 @@ export default function FilterMenu({ uniqueTags }) {
         >
           View projects
         </button>
-        <button className="btn" onClick={() => selectedTags.set([])}>
-          Reset filters
+        <button className="btn md:hidden" onClick={() => selectedTags.set([])}>
+          Reset
         </button>
       </div>
     </div>

--- a/src/components/projects/FilterMenu.jsx
+++ b/src/components/projects/FilterMenu.jsx
@@ -53,9 +53,13 @@ export default function FilterMenu({ uniqueTags }) {
         <TbX />
       </button>
       <div className="overflow-y-scroll md:overflow-hidden px-2">
-        <div className="flex items-center justify-between pt-2 pb-4">
-          <h3 className="hidden md:flex text-lg font-bold ">Filter by tag</h3>
-          <button className="btn-reset" onClick={() => selectedTags.set([])}>
+        {/* This h3 and button are visible only on medium and larger screen sizes */}
+        <div className="hidden md:flex items-center justify-between pt-2 pb-4">
+          <h3 className="text-lg font-bold ">Filter by tag</h3>
+          <button
+            className="btn-reset"
+            onClick={() => handleTagSelection(null)}
+          >
             Reset
           </button>
         </div>
@@ -104,7 +108,11 @@ export default function FilterMenu({ uniqueTags }) {
         >
           View projects
         </button>
-        <button className="btn md:hidden" onClick={() => selectedTags.set([])}>
+        {/* This reset button is visible on small screens */}
+        <button
+          className="btn md:hidden"
+          onClick={() => handleTagSelection(null)}
+        >
           Reset
         </button>
       </div>

--- a/src/components/projects/ProjectCount.jsx
+++ b/src/components/projects/ProjectCount.jsx
@@ -27,9 +27,9 @@ export default function ProjectCount({ allContent, contentType }) {
         $selectedTags.length === 0 ||
         tagsArray.some((tag) => $selectedTags.includes(tag));
       const matchesProjectType =
+        $selectedProjectType.length === 0 ||
         contentType === "ecosystems" ||
-        entry.data["project type"][0] === $selectedProjectType ||
-        $selectedProjectType === "All" ||
+        $selectedProjectType.includes(entry.data["project type"][0]) ||
         $selectedProjectType === null;
 
       return hasMatchingTags && matchesProjectType;
@@ -40,7 +40,7 @@ export default function ProjectCount({ allContent, contentType }) {
 
   return (
     <p
-      className={`font-semibold py-4 ${
+      className={`font-semibold text-lg py-4 ${
         contentType === "ecosystems" && "md:pt-0"
       }`}
     >

--- a/src/components/projects/ProjectTypeBtns.jsx
+++ b/src/components/projects/ProjectTypeBtns.jsx
@@ -1,61 +1,58 @@
-import { useEffect } from "react";
 import {
   selectedProjectType,
-  handleProjectTypeSelection,
+  handleProjectTypeButton,
 } from "./stores/selectedProjectTypeStore.js";
 import { useStore } from "@nanostores/react";
 
 export default function ProjectTypeSelector({ contentType }) {
   const $selectedProjectType = useStore(selectedProjectType);
 
-  function resetStoreAndSearchParams() {}
-
   return (
-    <div className={`${contentType === "ecosystems" && "hidden"} "pb-6"`}>
-      <div className="md:flex-col">
-        <div className="flex items-center justify-between pt-2 pb-4 gap-4">
-          <h3 className="hidden md:flex text-lg font-bold">
-            Filter by OSSI funding status
-          </h3>
-          <button
-            className="btn-reset"
-            onClick={(e) => handleProjectTypeSelection(null, e)}
-          >
-            Reset
-          </button>
-        </div>
-        <div className="hidden md:flex gap-4">
-          <button
-            className={`flex-1 btn-filter px-2 ${
-              $selectedProjectType.includes("OSSI - current")
-                ? "bg-primary dark:bg-primary text-white hover:bg-primary dark:hover:bg-primary"
-                : ""
-            }`}
-            onClick={(e) => handleProjectTypeSelection("OSSI - current", e)}
-          >
-            Current OSSI projects
-          </button>
-          <button
-            className={`flex-1 btn-filter px-2 ${
-              $selectedProjectType.includes("OSSI - previous")
-                ? "bg-primary dark:bg-primary text-white hover:bg-primary dark:hover:bg-primary"
-                : ""
-            }`}
-            onClick={(e) => handleProjectTypeSelection("OSSI - previous", e)}
-          >
-            Previous OSSI projects
-          </button>
-          <button
-            className={`flex-1 btn-filter px-2 ${
-              $selectedProjectType.includes("Other")
-                ? "bg-primary dark:bg-primary text-white hover:bg-primary dark:hover:bg-primary"
-                : ""
-            }`}
-            onClick={(e) => handleProjectTypeSelection("Other", e)}
-          >
-            Other projects
-          </button>
-        </div>
+    <div
+      className={`hidden ${
+        contentType === "ecosystems" ? "hidden" : "md:flex"
+      } flex-col pb-6`}
+    >
+      <div className="flex items-center justify-between pt-2 pb-4 gap-4">
+        <h3 className="text-lg font-bold">Filter by OSSI funding status</h3>
+        <button
+          className="btn-reset"
+          onClick={(e) => handleProjectTypeButton(null, e)}
+        >
+          Reset
+        </button>
+      </div>
+      <div className="hidden md:flex gap-4">
+        <button
+          className={`flex-1 btn-filter px-2 ${
+            $selectedProjectType.includes("OSSI - current")
+              ? "bg-primary dark:bg-primary text-white hover:bg-primary dark:hover:bg-primary"
+              : ""
+          }`}
+          onClick={(e) => handleProjectTypeButton("OSSI - current", e)}
+        >
+          Current OSSI projects
+        </button>
+        <button
+          className={`flex-1 btn-filter px-2 ${
+            $selectedProjectType.includes("OSSI - previous")
+              ? "bg-primary dark:bg-primary text-white hover:bg-primary dark:hover:bg-primary"
+              : ""
+          }`}
+          onClick={(e) => handleProjectTypeButton("OSSI - previous", e)}
+        >
+          Previous OSSI projects
+        </button>
+        <button
+          className={`flex-1 btn-filter px-2 ${
+            $selectedProjectType.includes("Other")
+              ? "bg-primary dark:bg-primary text-white hover:bg-primary dark:hover:bg-primary"
+              : ""
+          }`}
+          onClick={(e) => handleProjectTypeButton("Other", e)}
+        >
+          Other projects
+        </button>
       </div>
     </div>
   );

--- a/src/components/projects/ProjectTypeBtns.jsx
+++ b/src/components/projects/ProjectTypeBtns.jsx
@@ -1,53 +1,59 @@
-import { selectedProjectType } from "./stores/selectedProjectTypeStore.js";
+import { useEffect } from "react";
+import {
+  selectedProjectType,
+  handleProjectTypeSelection,
+} from "./stores/selectedProjectTypeStore.js";
 import { useStore } from "@nanostores/react";
 
 export default function ProjectTypeSelector({ contentType }) {
-  const currentProjectType = useStore(selectedProjectType);
+  const $selectedProjectType = useStore(selectedProjectType);
 
-  const handleButtonClick = (type) => {
-    selectedProjectType.set(type);
-  };
-
-  const isSelected = (type) => currentProjectType === type;
+  function resetStoreAndSearchParams() {}
 
   return (
     <div className={`${contentType === "ecosystems" && "hidden"} "pb-6"`}>
       <div className="md:flex-col">
-        <h3 className="hidden md:flex items-center justify-between py-2 font-bold ">
-          Filter by OSSI funding status
-        </h3>
+        <div className="flex items-center justify-between pt-2 pb-4 gap-4">
+          <h3 className="hidden md:flex text-lg font-bold">
+            Filter by OSSI funding status
+          </h3>
+          <button
+            className="btn-reset"
+            onClick={(e) => handleProjectTypeSelection(null, e)}
+          >
+            Reset
+          </button>
+        </div>
         <div className="hidden md:flex gap-4">
           <button
             className={`flex-1 btn-filter px-2 ${
-              isSelected("OSSI - current") ? "bg-primary text-white" : ""
+              $selectedProjectType.includes("OSSI - current")
+                ? "bg-primary dark:bg-primary text-white hover:bg-primary dark:hover:bg-primary"
+                : ""
             }`}
-            onClick={() => handleButtonClick("OSSI - current")}
+            onClick={(e) => handleProjectTypeSelection("OSSI - current", e)}
           >
             Current OSSI projects
           </button>
           <button
             className={`flex-1 btn-filter px-2 ${
-              isSelected("OSSI - previous") ? "bg-primary text-white" : ""
+              $selectedProjectType.includes("OSSI - previous")
+                ? "bg-primary dark:bg-primary text-white hover:bg-primary dark:hover:bg-primary"
+                : ""
             }`}
-            onClick={() => handleButtonClick("OSSI - previous")}
+            onClick={(e) => handleProjectTypeSelection("OSSI - previous", e)}
           >
             Previous OSSI projects
           </button>
           <button
             className={`flex-1 btn-filter px-2 ${
-              isSelected("Other") ? "bg-primary text-white" : ""
+              $selectedProjectType.includes("Other")
+                ? "bg-primary dark:bg-primary text-white hover:bg-primary dark:hover:bg-primary"
+                : ""
             }`}
-            onClick={() => handleButtonClick("Other")}
+            onClick={(e) => handleProjectTypeSelection("Other", e)}
           >
             Other projects
-          </button>
-          <button
-            className={`flex-1 btn-filter px-2 ${
-              isSelected("All") ? "bg-primary text-white" : ""
-            }`}
-            onClick={() => handleButtonClick("All")}
-          >
-            All projects
           </button>
         </div>
       </div>

--- a/src/components/projects/ProjectTypeDropdown.jsx
+++ b/src/components/projects/ProjectTypeDropdown.jsx
@@ -13,18 +13,21 @@ import { useStore } from "@nanostores/react";
 const getOptionColorClasses = ({ selected, highlighted, disabled }) => {
   let classes = "";
   if (disabled) {
+    // Note - the space at the beginning of each of these class segments is important. If removed, classes will
+    // smush together and then the beginning/ending class of each line won't be implemented
     classes += " text-slate-400 dark:text-slate-700";
   } else {
     classes +=
-      "hover:dark:bg-neutral-800 hover:bg-slate-100 hover:dark:text-slate-300 hover:text-slate-900";
-    if (selected) {
-      classes +=
-        "bg-primary dark:bg-primary hover:bg-primary hover:dark:bg-primary text-white dark:text-slate-100";
-      // } else if (highlighted) {
-      //   classes +=
-      //     " bg-slate-100 dark:bg-neutral-800 text-slate-900 dark:text-slate-300";
-    }
+      " hover:dark:bg-neutral-800 hover:bg-slate-100 hover:dark:text-slate-300 hover:text-slate-900";
   }
+  if (selected) {
+    classes +=
+      " bg-primary dark:bg-primary hover:bg-primary hover:dark:bg-primary text-white dark:text-slate-100";
+    // } else if (highlighted) {
+    //   classes +=
+    //     " bg-slate-100 dark:bg-neutral-800 text-slate-900 dark:text-slate-300";
+  }
+
   return classes;
 };
 

--- a/src/components/projects/ProjectTypeDropdown.jsx
+++ b/src/components/projects/ProjectTypeDropdown.jsx
@@ -65,7 +65,6 @@ Button.propTypes = {
 //Here is the customization of the component ------------------------------------
 export default function ProjectTypeDropdown() {
   const $selectedProjectType = useStore(selectedProjectType);
-  console.log("selected project type in dropdown: ", $selectedProjectType);
   const handleChange = (_, selectedArray) => {
     handleProjectTypeDropdown(selectedArray); // Update your store based on the new value
   };

--- a/src/components/projects/ProjectTypeDropdown.jsx
+++ b/src/components/projects/ProjectTypeDropdown.jsx
@@ -4,21 +4,26 @@ import { Select as BaseSelect } from "@mui/base/Select";
 import { Option as BaseOption } from "@mui/base/Option";
 import clsx from "clsx";
 import { TbSelector } from "react-icons/tb";
-import { selectedProjectType } from "./stores/selectedProjectTypeStore.js";
+import {
+  selectedProjectType,
+  handleProjectTypeDropdown,
+} from "./stores/selectedProjectTypeStore.js";
+import { useStore } from "@nanostores/react";
 
 const getOptionColorClasses = ({ selected, highlighted, disabled }) => {
   let classes = "";
   if (disabled) {
     classes += " text-slate-400 dark:text-slate-700";
   } else {
-    if (selected || highlighted) {
-      classes += " bg-primary text-white dark:text-slate-100";
+    classes +=
+      "hover:dark:bg-neutral-800 hover:bg-slate-100 hover:dark:text-slate-300 hover:text-slate-900";
+    if (selected) {
+      classes +=
+        "bg-primary dark:bg-primary hover:bg-primary hover:dark:bg-primary text-white dark:text-slate-100";
       // } else if (highlighted) {
       //   classes +=
       //     " bg-slate-100 dark:bg-neutral-800 text-slate-900 dark:text-slate-300";
     }
-    classes +=
-      "hover:dark:bg-neutral-800 hover:bg-slate-100 hover:dark:text-slate-300 hover:text-slate-900";
   }
   return classes;
 };
@@ -54,12 +59,16 @@ Button.propTypes = {
   ownerState: PropTypes.object.isRequired,
 };
 
+//Here is the customization of the component ------------------------------------
 export default function ProjectTypeDropdown() {
+  const $selectedProjectType = useStore(selectedProjectType);
+  console.log("selected project type in dropdown: ", $selectedProjectType);
+  const handleChange = (_, selectedArray) => {
+    handleProjectTypeDropdown(selectedArray); // Update your store based on the new value
+  };
+
   return (
-    <Select
-      defaultValue="OSSI - current"
-      onChange={(event, newValue) => selectedProjectType.set(newValue)}
-    >
+    <Select multiple value={$selectedProjectType} onChange={handleChange}>
       <Option
         key="OSSI - current"
         value="OSSI - current"
@@ -77,20 +86,16 @@ export default function ProjectTypeDropdown() {
       <Option key="Other" value="Other" className="cursor-pointer my-1">
         Other
       </Option>
-      <Option key="All" value="All" className="cursor-pointer my-1">
-        All
-      </Option>
     </Select>
   );
 }
+// -----------------------------------------------------------------
 
 const resolveSlotProps = (fn, args) =>
   typeof fn === "function" ? fn(args) : fn;
 
+// I added the prop "multiple" to allow for multiple selections
 const Select = React.forwardRef(function CustomSelect(props, ref) {
-  // Replace this with your app logic for determining dark modes
-  //   const isDarkMode = useIsDarkMode();
-
   return (
     <BaseSelect
       ref={ref}

--- a/src/components/projects/ToggleFilterMenuBtn.jsx
+++ b/src/components/projects/ToggleFilterMenuBtn.jsx
@@ -5,18 +5,10 @@ import { isFilterMenuVisible } from "./stores/isFilterMenuVisibleStore";
 import { TbAdjustmentsHorizontal } from "react-icons/tb";
 
 export default function ToggleFilterMenuBtn({ uniqueTags }) {
+  // console.log("unique tags:", uniqueTags);
   const $isFilterMenuVisible = useStore(isFilterMenuVisible);
   const $selectedTags = useStore(selectedTags);
-  const filteredTags = $selectedTags.filter(
-    (tag) =>
-      // Check if tag is a value in any of the arrays in uniqueTags
-      Object.values(uniqueTags).some((uniqueTagsArray) =>
-        uniqueTagsArray.includes(tag)
-      ) || tag === ""
-  );
-
-  // Set numFilters to the length of the filteredTags array
-  const numFilters = filteredTags.length;
+  const numFilters = $selectedTags.length;
 
   return (
     <Badge

--- a/src/components/projects/ToggleFilterMenuBtn.jsx
+++ b/src/components/projects/ToggleFilterMenuBtn.jsx
@@ -4,10 +4,19 @@ import { selectedTags } from "./stores/selectedTagsStore";
 import { isFilterMenuVisible } from "./stores/isFilterMenuVisibleStore";
 import { TbAdjustmentsHorizontal } from "react-icons/tb";
 
-export default function ToggleFilterMenuBtn() {
+export default function ToggleFilterMenuBtn({ uniqueTags }) {
   const $isFilterMenuVisible = useStore(isFilterMenuVisible);
   const $selectedTags = useStore(selectedTags);
-  const numFilters = $selectedTags.length;
+  const filteredTags = $selectedTags.filter(
+    (tag) =>
+      // Check if tag is a value in any of the arrays in uniqueTags
+      Object.values(uniqueTags).some((uniqueTagsArray) =>
+        uniqueTagsArray.includes(tag)
+      ) || tag === ""
+  );
+
+  // Set numFilters to the length of the filteredTags array
+  const numFilters = filteredTags.length;
 
   return (
     <Badge

--- a/src/components/projects/stores/selectedProjectTypeStore.js
+++ b/src/components/projects/stores/selectedProjectTypeStore.js
@@ -10,7 +10,6 @@ function updateProjectTypeSearchParams(updatedProjectType) {
 
     searchParams.delete("projectType");
 
-    // Add each tag as a separate 'tags' parameter
     updatedProjectType.forEach((projectType) =>
       searchParams.append("projectType", projectType)
     );
@@ -21,7 +20,6 @@ function updateProjectTypeSearchParams(updatedProjectType) {
 }
 
 export function handleProjectTypeButton(type, e) {
-  console.log("type passed to project type store: ", type);
   const prevProjectType = selectedProjectType.get();
   let updatedProjectType = [];
 
@@ -41,7 +39,6 @@ export function handleProjectTypeButton(type, e) {
 }
 
 export function handleProjectTypeDropdown(type) {
-  console.log("type passed to project type store: ", type);
   selectedProjectType.set(type);
   updateProjectTypeSearchParams(type);
 }

--- a/src/components/projects/stores/selectedProjectTypeStore.js
+++ b/src/components/projects/stores/selectedProjectTypeStore.js
@@ -2,7 +2,26 @@ import { atom } from "nanostores";
 
 export const selectedProjectType = atom([]);
 
-export function handleProjectTypeSelection(type, e) {
+function updateProjectTypeSearchParams(updatedProjectType) {
+  // update URL search params
+  if (typeof window !== "undefined") {
+    const currentUrl = new URL(window.location);
+    const searchParams = new URLSearchParams(currentUrl.search);
+
+    searchParams.delete("projectType");
+
+    // Add each tag as a separate 'tags' parameter
+    updatedProjectType.forEach((projectType) =>
+      searchParams.append("projectType", projectType)
+    );
+
+    // Use history.pushState to update the URL without reloading the page
+    window.history.pushState({}, "", `${currentUrl.pathname}?${searchParams}`);
+  }
+}
+
+export function handleProjectTypeButton(type, e) {
+  console.log("type passed to project type store: ", type);
   const prevProjectType = selectedProjectType.get();
   let updatedProjectType = [];
 
@@ -18,25 +37,13 @@ export function handleProjectTypeSelection(type, e) {
     e.currentTarget.blur();
   }
 
-  // update URL search params
-  if (typeof window !== "undefined") {
-    const currentUrl = new URL(window.location);
-    const searchParams = new URLSearchParams(currentUrl.search);
-
-    searchParams.delete("projectType");
-
-    // Add each tag as a separate 'tags' parameter
-    if (type != null) {
-      updatedProjectType.forEach((projectType) =>
-        searchParams.append("projectType", projectType)
-      );
-
-      // Use history.pushState to update the URL without reloading the page
-      window.history.pushState(
-        {},
-        "",
-        `${currentUrl.pathname}?${searchParams}`
-      );
-    }
+  if (type != null) {
+    updateProjectTypeSearchParams(updatedProjectType);
   }
+}
+
+export function handleProjectTypeDropdown(type) {
+  console.log("type passed to project type store: ", type);
+  selectedProjectType.set(type);
+  updateProjectTypeSearchParams(type);
 }

--- a/src/components/projects/stores/selectedProjectTypeStore.js
+++ b/src/components/projects/stores/selectedProjectTypeStore.js
@@ -1,3 +1,42 @@
 import { atom } from "nanostores";
 
-export const selectedProjectType = atom(null);
+export const selectedProjectType = atom([]);
+
+export function handleProjectTypeSelection(type, e) {
+  const prevProjectType = selectedProjectType.get();
+  let updatedProjectType = [];
+
+  if (prevProjectType.includes(type)) {
+    updatedProjectType = prevProjectType.filter((t) => t !== type); // Remove type if it's already selected
+  } else if (type != null) {
+    updatedProjectType = [...prevProjectType, type]; // Add type if it's not already selected
+  }
+  selectedProjectType.set(updatedProjectType);
+
+  // Blur the button to remove focus
+  if (e) {
+    e.currentTarget.blur();
+  }
+
+  // update URL search params
+  if (typeof window !== "undefined") {
+    const currentUrl = new URL(window.location);
+    const searchParams = new URLSearchParams(currentUrl.search);
+
+    searchParams.delete("projectType");
+
+    // Add each tag as a separate 'tags' parameter
+    if (type != null) {
+      updatedProjectType.forEach((projectType) =>
+        searchParams.append("projectType", projectType)
+      );
+
+      // Use history.pushState to update the URL without reloading the page
+      window.history.pushState(
+        {},
+        "",
+        `${currentUrl.pathname}?${searchParams}`
+      );
+    }
+  }
+}

--- a/src/components/projects/stores/selectedProjectTypeStore.js
+++ b/src/components/projects/stores/selectedProjectTypeStore.js
@@ -37,9 +37,7 @@ export function handleProjectTypeButton(type, e) {
     e.currentTarget.blur();
   }
 
-  if (type != null) {
-    updateProjectTypeSearchParams(updatedProjectType);
-  }
+  updateProjectTypeSearchParams(updatedProjectType);
 }
 
 export function handleProjectTypeDropdown(type) {

--- a/src/components/projects/stores/selectedTagsStore.js
+++ b/src/components/projects/stores/selectedTagsStore.js
@@ -3,13 +3,31 @@ import { atom } from "nanostores";
 export const selectedTags = atom([]);
 
 export function handleTagSelection(tag) {
-  const prevTags = selectedTags.get(selectedTags);
+  // access and update tags store
+  const prevTags = selectedTags.get();
   const tagIndex = prevTags.indexOf(tag);
 
+  let updatedTags = [];
+
   if (tagIndex === -1) {
-    selectedTags.set([...prevTags, tag]);
+    updatedTags = [...prevTags, tag];
   } else {
-    const updatedTags = prevTags.filter((t, index) => index !== tagIndex);
-    selectedTags.set(updatedTags);
+    updatedTags = prevTags.filter((t, index) => index !== tagIndex);
+  }
+  selectedTags.set(updatedTags);
+
+  // update URL search params
+  if (typeof window !== "undefined") {
+    const currentUrl = new URL(window.location);
+    const searchParams = new URLSearchParams(currentUrl.search);
+
+    // Remove all current 'tags' entries
+    searchParams.delete("tags");
+
+    // Add each tag as a separate 'tags' parameter
+    updatedTags.forEach((tag) => searchParams.append("tags", tag));
+
+    // Use history.pushState to update the URL without reloading the page
+    window.history.pushState({}, "", `${currentUrl.pathname}?${searchParams}`);
   }
 }

--- a/src/components/projects/stores/selectedTagsStore.js
+++ b/src/components/projects/stores/selectedTagsStore.js
@@ -3,6 +3,7 @@ import { atom } from "nanostores";
 export const selectedTags = atom([]);
 
 export function handleTagSelection(tag) {
+  console.log("tag passed to tag store: ", tag);
   // access and update tags store
   const prevTags = selectedTags.get();
   const tagIndex = prevTags.indexOf(tag);
@@ -14,6 +15,7 @@ export function handleTagSelection(tag) {
   } else {
     updatedTags = prevTags.filter((t, index) => index !== tagIndex);
   }
+  console.log("updated tags: ", updatedTags);
   selectedTags.set(updatedTags);
 
   // update URL search params
@@ -24,8 +26,10 @@ export function handleTagSelection(tag) {
     // Remove all current 'tags' entries
     searchParams.delete("tags");
 
-    // Add each tag as a separate 'tags' parameter
-    updatedTags.forEach((tag) => searchParams.append("tags", tag));
+    if (updatedTags.length != 0) {
+      // Add each tag as a separate 'tags' parameter
+      updatedTags.forEach((tag) => searchParams.append("tags", tag));
+    }
 
     // Use history.pushState to update the URL without reloading the page
     window.history.pushState({}, "", `${currentUrl.pathname}?${searchParams}`);

--- a/src/components/projects/stores/selectedTagsStore.js
+++ b/src/components/projects/stores/selectedTagsStore.js
@@ -2,36 +2,31 @@ import { atom } from "nanostores";
 
 export const selectedTags = atom([]);
 
-export function handleTagSelection(tag) {
-  console.log("tag passed to tag store: ", tag);
-  // access and update tags store
-  const prevTags = selectedTags.get();
-  const tagIndex = prevTags.indexOf(tag);
-
-  let updatedTags = [];
-
-  if (tagIndex === -1) {
-    updatedTags = [...prevTags, tag];
-  } else {
-    updatedTags = prevTags.filter((t, index) => index !== tagIndex);
-  }
-  console.log("updated tags: ", updatedTags);
-  selectedTags.set(updatedTags);
-
+function updateTagsSearchParams(updatedTags) {
   // update URL search params
   if (typeof window !== "undefined") {
     const currentUrl = new URL(window.location);
     const searchParams = new URLSearchParams(currentUrl.search);
 
-    // Remove all current 'tags' entries
-    searchParams.delete("tags");
+    searchParams.delete("tag");
 
-    if (updatedTags.length != 0) {
-      // Add each tag as a separate 'tags' parameter
-      updatedTags.forEach((tag) => searchParams.append("tags", tag));
-    }
+    updatedTags.forEach((tag) => searchParams.append("tag", tag));
 
     // Use history.pushState to update the URL without reloading the page
     window.history.pushState({}, "", `${currentUrl.pathname}?${searchParams}`);
   }
+}
+
+export function handleTagSelection(tag) {
+  const prevTags = selectedTags.get();
+  let updatedTags = [];
+
+  if (prevTags.includes(tag)) {
+    updatedTags = prevTags.filter((t) => t !== tag); // Remove tag if it's already selected
+  } else if (tag != null) {
+    updatedTags = [...prevTags, tag]; // Add tag if it's not already selected
+  }
+  selectedTags.set(updatedTags);
+
+  updateTagsSearchParams(updatedTags);
 }

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -22,10 +22,10 @@ const uniqueTags = extractUniqueTagsObject(allProjects);
     client:load
     baseUrl={baseUrl}
     title="Software Projects"
-    subtitle='Software developed at Janelia, including OSSI-funded projects'
+    subtitle="Software developed at Janelia, including OSSI-funded projects"
   />
   <CardsAndFiltersIsland
-    client:load
+    client:only
     uniqueTags={uniqueTags}
     allContent={allProjects}
     baseUrl={baseUrl}

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -33,8 +33,12 @@
     @apply btn rounded-md shadow-none p-1 md:py-4 md:px-8 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white;
   }
 
+  .btn-reset {
+    @apply btn border border-slate-300 py-0 px-2 rounded-md gap-1 hover:border-slate-300 dark:border-slate-700 dark:bg-slate-800 dark:hover:bg-slate-700;
+  }
+
   .btn-filter {
-    @apply btn rounded-md shadow-none p-1 md:py-4 md:px-8 border-2 dark:border-slate-400 hover:bg-primary hover:border-primary dark:hover:bg-primary focus:bg-primary focus:border-primary;
+    @apply btn-reset p-1 md:py-4 md:px-8;
   }
 }
 


### PR DESCRIPTION
Search params for tags and project type are added to the URL when filtering projects or ecosystems. In addition, a URL for `projects/` or `ecosystems/` with search params for `tag` or `projectType` will open a page with the projects filtered to these values. 

Closes #108. Also closes #158, because the project type nanostore was changed to an array, allowing selection of multiple project types at once.