### PR TITLE
Fix: filter menu stays open when user deselects tag

### DIFF
--- a/src/components/projects/FilterMenu.jsx
+++ b/src/components/projects/FilterMenu.jsx
@@ -24,11 +24,12 @@ export default function FilterMenu({ uniqueTags }) {
 
   // Effect to update categoryVisibility when $selectedTags changes
   useEffect(() => {
+    const prevVisibility = categoryVisibility;
     const newVisibility = {};
     Object.keys(uniqueTags).forEach((key) => {
-      newVisibility[key] = uniqueTags[key].some((tag) =>
-        $selectedTags.includes(tag)
-      );
+      newVisibility[key] =
+        prevVisibility[key] ||
+        uniqueTags[key].some((tag) => $selectedTags.includes(tag));
     });
     setCategoryVisibility(newVisibility);
   }, [$selectedTags]);


### PR DESCRIPTION
This fix allows the user to deselect all the tags within a filter menu category without the filter menu category then automatically closing.