### PR TITLE
fix: card randomization now occurs client-side, as opposed to build time

### DIFF
--- a/src/components/projects/CardContainer.jsx
+++ b/src/components/projects/CardContainer.jsx
@@ -16,6 +16,7 @@ export default function CardContainer({
   cardImage,
   cardContent,
   contentType,
+  maxLength,
 }) {
   const [visible, setVisible] = useState("relative");
   const [order, setOrder] = useState(0);
@@ -41,18 +42,19 @@ export default function CardContainer({
     if (!contentData) {
       return -1;
     }
-
     const index = contentData.findIndex(
       (content) => content.item.title === title
     );
     return index;
   }
 
+  //set card order in the grid/flexbox (random if no search query; otherwise based on Fuse score) and
   //determine whether card is visible or not based on: search query, tag selections, project type selections
   useEffect(() => {
     if (typeof window !== "undefined") {
       const matchingIndex = findMatchingIndex(contentData, title);
-      const itemOrder = matchingIndex + 1;
+      const itemOrder =
+        urlQuery === "" ? Math.floor(Math.random() * maxLength) : matchingIndex;
       setOrder(itemOrder);
 
       const isSearchMatch =

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -19,18 +19,9 @@ import ToggleFilterMenuBtn from "../../components/projects/ToggleFilterMenuBtn";
 
 import { extractUniqueTagsObject } from "../../utils/tagManipulation.js";
 
-function shuffleArray(array) {
-  for (let i = array.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [array[i], array[j]] = [array[j], array[i]]; // Swap elements
-  }
-  return array;
-}
-
 const baseUrl = import.meta.env.BASE_URL;
 const pageTitle = "OSSI-supported projects";
-let allProjects = await getCollection("projects");
-allProjects = shuffleArray(allProjects);
+const allProjects = await getCollection("projects");
 
 // uniqueTags is an object where keys = unique tag categories, values = unique tags within a category, both across allProjects. All lowercase.
 // used to populate the filter menu
@@ -85,7 +76,6 @@ const uniqueTags = extractUniqueTagsObject(allProjects);
         {
           allProjects.map((content) => {
             const tagsObj = extractUniqueTagsObject(content);
-            // console.log("tagsObj", tagsObj);
             return (
               <CardContainer
                 key={content.slug}
@@ -94,6 +84,7 @@ const uniqueTags = extractUniqueTagsObject(allProjects);
                 tagsObj={tagsObj}
                 projectType={content.data["project type"][0]}
                 contentType="projects"
+                maxLength={allProjects.length}
                 client:only="react"
               >
                 {content.data["image file"] ? (
@@ -116,7 +107,6 @@ const uniqueTags = extractUniqueTagsObject(allProjects);
                 />
                 <Fragment slot="tags">
                   {Object.entries(tagsObj).map(([tagCat, tags]) => {
-                    // console.log(tags);
                     return tags.map((tag) => {
                       return (
                         <Tag tagCat={tagCat} tag={tag} contentType="projects" />


### PR DESCRIPTION
Addresses #246. Fixes an unsuccessful previous attempt (commit #248) that only did the randomization of the cards once, at build time. Randomization now occurs on the client. 