### PR TITLE
Update STIM citation

### DIFF
--- a/src/content/projects/stim.md
+++ b/src/content/projects/stim.md
@@ -8,8 +8,8 @@ OSSI project status: [Active Development]
 OSSI proposal link: ../../proposals/spatial_transcriptomics_tools.pdf
 github link: https://github.com/PreibischLab/STIM
 documentation link: https://github.com/PreibischLab/STIM/wiki
-how to cite link: https://doi.org/10.1101/2021.12.07.471629
-how to cite text: "S. Preibisch, N. Karaiskos, N.Rajewsky, Image-based representation of massive spatial transcriptomics datasets, bioRxiv 2021.12.07.471629 (2021)."
+how to cite link: https://doi.org/10.1016/j.cels.2025.101264
+how to cite text: "S. Preibisch, N. Karaiskos, N.Rajewsky, Scalable image-based visualization and alignment of spatial transcriptomics datasets. Cell Systems, Vol. 16, No. 5 (2025)."
 # related blog posts: [Optional-file-name]
 image file: ./stim-1.png
 image caption: 3D rendering of THE SlideSeq multi-layer sequence-based transcriptomics dataset (calm-2, ptgds, mbp)


### PR DESCRIPTION
Since the accompanying paper reached a stable publication state, I've updated the citation and doi.

I've also noticed that the README of the project is not shown on the OSSI website anymore, even in the [live version](https://ossi.janelia.org/projects/stim/) (see screenshot below). I suspect that this comes from me updating the README previously and that this is a only a transient problem. Let me know if I can do anything to fix the problem. Thanks!

![image](https://github.com/user-attachments/assets/2accc72f-e6b7-4d89-bf12-14aaff4e8197)
